### PR TITLE
Track SCALAR/INTEGER precision via COMMON0.out symbol table

### DIFF
--- a/emu/halmat.h
+++ b/emu/halmat.h
@@ -304,6 +304,7 @@ int  halmat_load(halmat_t *H, const char *filename);
 int  halmat_load_litfile(halmat_t *H, const char *filename);
 int  halmat_load_strings(halmat_t *H, const char *source_file);
 int  halmat_load_common0(halmat_t *H, const char *filename);
+int  halmat_load_symtab(halmat_t *H, const char *filename);
 void halmat_free_common0(halmat_t *H);
 void halmat_build_flow_table(halmat_t *H);
 void halmat_init(halmat_t *H);

--- a/emu/halmat_class0.c
+++ b/emu/halmat_class0.c
@@ -293,9 +293,21 @@ int halmat_exec_class0(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         }
 
         if (loop_var < HALMAT_MAX_SYT) {
-            H->syt[loop_var].val.type = HTYPE_SCALAR;
-            H->syt[loop_var].val.v.scalar = init_val.v.scalar;
-            H->syt[loop_var].allocated = 1;
+            syt_entry_t *lv = &H->syt[loop_var];
+            uint8_t want = lv->declared ? lv->val.type : HTYPE_SCALAR;
+            if (want == HTYPE_INTEGER) {
+                int32_t v = (init_val.type == HTYPE_SCALAR)
+                    ? (int32_t)init_val.v.scalar : init_val.v.integer;
+                if (lv->val.precision == HPREC_SINGLE)
+                    v = (int32_t)(int16_t)v;
+                lv->val.type = HTYPE_INTEGER;
+                lv->val.v.integer = v;
+            } else {
+                lv->val.type = HTYPE_SCALAR;
+                lv->val.v.scalar = (init_val.type == HTYPE_INTEGER)
+                    ? (double)init_val.v.integer : init_val.v.scalar;
+            }
+            lv->allocated = 1;
         }
 
         loop_info_t *loop = &H->loops[H->loop_depth++];

--- a/emu/halmat_class5.c
+++ b/emu/halmat_class5.c
@@ -1,6 +1,29 @@
 #include "halmat.h"
 #include <math.h>
 
+static double scal_val(halmat_val_t v)
+{
+    return (v.type == HTYPE_INTEGER) ? (double)v.v.integer : v.v.scalar;
+}
+
+/* HAL/S Programmer's Guide p.75: a binary op runs at the precision of
+ * its wider operand. Narrowing on store happens at SASN, not here. */
+static uint8_t wider_prec(halmat_val_t a, halmat_val_t b)
+{
+    return (a.precision > b.precision) ? a.precision : b.precision;
+}
+
+/* IBM single is 24-bit hex mantissa, same bit count as IEEE single,
+ * so a (float) round-trip is the right narrowing. Without this,
+ * SCALAR and SCALAR DOUBLE held identical bit patterns and X - X2
+ * always came out exactly zero in Ron's test (issue #10). */
+static double narrow_to_dest(double v, uint8_t dest_prec)
+{
+    if (dest_prec == HPREC_SINGLE)
+        return (double)(float)v;
+    return v;
+}
+
 int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t tag)
 {
     uint32_t pc = H->pc;
@@ -11,10 +34,12 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         if (numop < 2) break;
         halmat_val_t src = halmat_resolve_operand(H, H->code[pc + 1]);
         uint32_t dest = HALMAT_DATA(H->code[pc + 2]);
-        double val = (src.type == HTYPE_INTEGER) ? (double)src.v.integer : src.v.scalar;
         if (dest < HALMAT_MAX_SYT) {
+            uint8_t prec = H->syt[dest].declared ? H->syt[dest].val.precision
+                                                 : src.precision;
             H->syt[dest].val.type = HTYPE_SCALAR;
-            H->syt[dest].val.v.scalar = val;
+            H->syt[dest].val.precision = prec;
+            H->syt[dest].val.v.scalar = narrow_to_dest(scal_val(src), prec);
             H->syt[dest].allocated = 1;
         }
         break;
@@ -24,11 +49,10 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         if (numop < 2) break;
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t b = halmat_resolve_operand(H, H->code[pc + 2]);
-        double va = (a.type == HTYPE_INTEGER) ? (double)a.v.integer : a.v.scalar;
-        double vb = (b.type == HTYPE_INTEGER) ? (double)b.v.integer : b.v.scalar;
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
-        r.v.scalar = va + vb;
+        r.precision = wider_prec(a, b);
+        r.v.scalar = scal_val(a) + scal_val(b);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -37,11 +61,10 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         if (numop < 2) break;
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t b = halmat_resolve_operand(H, H->code[pc + 2]);
-        double va = (a.type == HTYPE_INTEGER) ? (double)a.v.integer : a.v.scalar;
-        double vb = (b.type == HTYPE_INTEGER) ? (double)b.v.integer : b.v.scalar;
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
-        r.v.scalar = va - vb;
+        r.precision = wider_prec(a, b);
+        r.v.scalar = scal_val(a) - scal_val(b);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -50,11 +73,10 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         if (numop < 2) break;
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t b = halmat_resolve_operand(H, H->code[pc + 2]);
-        double va = (a.type == HTYPE_INTEGER) ? (double)a.v.integer : a.v.scalar;
-        double vb = (b.type == HTYPE_INTEGER) ? (double)b.v.integer : b.v.scalar;
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
-        r.v.scalar = va * vb;
+        r.precision = wider_prec(a, b);
+        r.v.scalar = scal_val(a) * scal_val(b);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -63,15 +85,15 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         if (numop < 2) break;
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t b = halmat_resolve_operand(H, H->code[pc + 2]);
-        double va = (a.type == HTYPE_INTEGER) ? (double)a.v.integer : a.v.scalar;
-        double vb = (b.type == HTYPE_INTEGER) ? (double)b.v.integer : b.v.scalar;
+        double vb = scal_val(b);
         if (vb == 0.0) {
             H->pc = pc + numop + 1;
             return HALMAT_ERR_DIV_ZERO;
         }
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
-        r.v.scalar = va / vb;
+        r.precision = wider_prec(a, b);
+        r.v.scalar = scal_val(a) / vb;
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -80,11 +102,10 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         if (numop < 2) break;
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t b = halmat_resolve_operand(H, H->code[pc + 2]);
-        double va = (a.type == HTYPE_INTEGER) ? (double)a.v.integer : a.v.scalar;
-        double vb = (b.type == HTYPE_INTEGER) ? (double)b.v.integer : b.v.scalar;
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
-        r.v.scalar = pow(va, vb);
+        r.precision = wider_prec(a, b);
+        r.v.scalar = pow(scal_val(a), scal_val(b));
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -93,10 +114,11 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         if (numop < 2) break;
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t b = halmat_resolve_operand(H, H->code[pc + 2]);
-        double base = (a.type == HTYPE_INTEGER) ? (double)a.v.integer : a.v.scalar;
+        double base = scal_val(a);
         int exp = (b.type == HTYPE_INTEGER) ? b.v.integer : (int)b.v.scalar;
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
+        r.precision = a.precision;
         r.v.scalar = pow(base, (double)exp);
         halmat_store_vac(H, pc, r);
         break;
@@ -106,11 +128,10 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         if (numop < 2) break;
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t b = halmat_resolve_operand(H, H->code[pc + 2]);
-        double va = (a.type == HTYPE_INTEGER) ? (double)a.v.integer : a.v.scalar;
-        double vb = (b.type == HTYPE_INTEGER) ? (double)b.v.integer : b.v.scalar;
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
-        r.v.scalar = pow(va, vb);
+        r.precision = wider_prec(a, b);
+        r.v.scalar = pow(scal_val(a), scal_val(b));
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -118,10 +139,10 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
     case POP_SNEG: {
         if (numop < 1) break;
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
-        double va = (a.type == HTYPE_INTEGER) ? (double)a.v.integer : a.v.scalar;
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
-        r.v.scalar = -va;
+        r.precision = a.precision;
+        r.v.scalar = -scal_val(a);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -131,7 +152,8 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
-        r.v.scalar = (a.type == HTYPE_INTEGER) ? (double)a.v.integer : a.v.scalar;
+        r.precision = (a.precision == HPREC_DOUBLE) ? HPREC_DOUBLE : HPREC_SINGLE;
+        r.v.scalar = scal_val(a);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -141,7 +163,8 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
-        r.v.scalar = (a.type == HTYPE_INTEGER) ? (double)a.v.integer : a.v.scalar;
+        r.precision = a.precision;
+        r.v.scalar = scal_val(a);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -151,6 +174,7 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
+        r.precision = HPREC_SINGLE;
         r.v.scalar = (double)a.v.bits;
         halmat_store_vac(H, pc, r);
         break;
@@ -159,6 +183,7 @@ int halmat_exec_class5(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
     case POP_CTOS: {
         halmat_val_t r = {0};
         r.type = HTYPE_SCALAR;
+        r.precision = HPREC_SINGLE;
         r.v.scalar = 0.0;
         halmat_store_vac(H, pc, r);
         break;

--- a/emu/halmat_class6.c
+++ b/emu/halmat_class6.c
@@ -13,6 +13,21 @@ static int32_t to_int(halmat_val_t v)
     }
 }
 
+/* Ron's AP-101S trace (LH/MR/SLL/STH on Don's emulator) confirmed
+ * INTEGER arithmetic wraps mod 2^16, INTEGER DOUBLE mod 2^32.
+ * No saturation. See issue #11. */
+static int32_t narrow_int(int32_t v, uint8_t prec)
+{
+    if (prec == HPREC_SINGLE)
+        return (int32_t)(int16_t)v;
+    return v;
+}
+
+static uint8_t wider_prec(halmat_val_t a, halmat_val_t b)
+{
+    return (a.precision > b.precision) ? a.precision : b.precision;
+}
+
 int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t tag)
 {
     uint32_t pc = H->pc;
@@ -24,8 +39,11 @@ int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t src = halmat_resolve_operand(H, H->code[pc + 1]);
         uint32_t dest = HALMAT_DATA(H->code[pc + 2]);
         if (dest < HALMAT_MAX_SYT) {
+            uint8_t prec = H->syt[dest].declared ? H->syt[dest].val.precision
+                                                 : src.precision;
             H->syt[dest].val.type = HTYPE_INTEGER;
-            H->syt[dest].val.v.integer = to_int(src);
+            H->syt[dest].val.precision = prec;
+            H->syt[dest].val.v.integer = narrow_int(to_int(src), prec);
             H->syt[dest].allocated = 1;
         }
         break;
@@ -37,7 +55,8 @@ int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t b = halmat_resolve_operand(H, H->code[pc + 2]);
         halmat_val_t r = {0};
         r.type = HTYPE_INTEGER;
-        r.v.integer = to_int(a) + to_int(b);
+        r.precision = wider_prec(a, b);
+        r.v.integer = narrow_int(to_int(a) + to_int(b), r.precision);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -48,7 +67,8 @@ int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t b = halmat_resolve_operand(H, H->code[pc + 2]);
         halmat_val_t r = {0};
         r.type = HTYPE_INTEGER;
-        r.v.integer = to_int(a) - to_int(b);
+        r.precision = wider_prec(a, b);
+        r.v.integer = narrow_int(to_int(a) - to_int(b), r.precision);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -59,7 +79,8 @@ int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t b = halmat_resolve_operand(H, H->code[pc + 2]);
         halmat_val_t r = {0};
         r.type = HTYPE_INTEGER;
-        r.v.integer = to_int(a) * to_int(b);
+        r.precision = wider_prec(a, b);
+        r.v.integer = narrow_int(to_int(a) * to_int(b), r.precision);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -69,7 +90,8 @@ int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t r = {0};
         r.type = HTYPE_INTEGER;
-        r.v.integer = -to_int(a);
+        r.precision = a.precision;
+        r.v.integer = narrow_int(-to_int(a), r.precision);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -85,7 +107,8 @@ int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
             result *= base;
         halmat_val_t r = {0};
         r.type = HTYPE_INTEGER;
-        r.v.integer = result;
+        r.precision = wider_prec(a, b);
+        r.v.integer = narrow_int(result, r.precision);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -95,7 +118,8 @@ int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t r = {0};
         r.type = HTYPE_INTEGER;
-        r.v.integer = to_int(a);
+        r.precision = (a.precision == HPREC_DOUBLE) ? HPREC_DOUBLE : HPREC_SINGLE;
+        r.v.integer = narrow_int(to_int(a), r.precision);
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -105,7 +129,8 @@ int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t r = {0};
         r.type = HTYPE_INTEGER;
-        r.v.integer = (int32_t)a.v.bits;
+        r.precision = HPREC_SINGLE;
+        r.v.integer = (int32_t)(int16_t)a.v.bits;
         halmat_store_vac(H, pc, r);
         break;
     }
@@ -113,6 +138,7 @@ int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
     case POP_CTOI: {
         halmat_val_t r = {0};
         r.type = HTYPE_INTEGER;
+        r.precision = HPREC_SINGLE;
         r.v.integer = 0;
         halmat_store_vac(H, pc, r);
         break;
@@ -123,7 +149,8 @@ int halmat_exec_class6(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         halmat_val_t a = halmat_resolve_operand(H, H->code[pc + 1]);
         halmat_val_t r = {0};
         r.type = HTYPE_INTEGER;
-        r.v.integer = to_int(a);
+        r.precision = a.precision;
+        r.v.integer = narrow_int(to_int(a), r.precision);
         halmat_store_vac(H, pc, r);
         break;
     }

--- a/emu/halmat_class8.c
+++ b/emu/halmat_class8.c
@@ -1,4 +1,5 @@
 #include "halmat.h"
+#include <math.h>
 
 int halmat_exec_class8(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t tag)
 {
@@ -11,12 +12,15 @@ int halmat_exec_class8(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         uint32_t dest = HALMAT_DATA(H->code[pc + 1]);
         halmat_val_t src = halmat_resolve_operand(H, H->code[pc + 2]);
         if (dest < HALMAT_MAX_SYT) {
+            uint8_t prec = H->syt[dest].declared ? H->syt[dest].val.precision
+                                                 : src.precision;
+            int32_t v = (src.type == HTYPE_SCALAR) ? (int32_t)round(src.v.scalar)
+                                                   : src.v.integer;
+            if (prec == HPREC_SINGLE)
+                v = (int32_t)(int16_t)v;
             H->syt[dest].val.type = HTYPE_INTEGER;
-            /* literals are IBM float */
-            if (src.type == HTYPE_SCALAR)
-                H->syt[dest].val.v.integer = (int32_t)src.v.scalar;
-            else
-                H->syt[dest].val.v.integer = src.v.integer;
+            H->syt[dest].val.precision = prec;
+            H->syt[dest].val.v.integer = v;
             H->syt[dest].allocated = 1;
         }
         break;
@@ -27,11 +31,15 @@ int halmat_exec_class8(halmat_t *H, uint32_t popcode, uint32_t numop, uint32_t t
         uint32_t dest = HALMAT_DATA(H->code[pc + 1]);
         halmat_val_t src = halmat_resolve_operand(H, H->code[pc + 2]);
         if (dest < HALMAT_MAX_SYT) {
+            uint8_t prec = H->syt[dest].declared ? H->syt[dest].val.precision
+                                                 : src.precision;
+            double v = (src.type == HTYPE_INTEGER) ? (double)src.v.integer
+                                                   : src.v.scalar;
+            if (prec == HPREC_SINGLE)
+                v = (double)(float)v;
             H->syt[dest].val.type = HTYPE_SCALAR;
-            if (src.type == HTYPE_INTEGER)
-                H->syt[dest].val.v.scalar = (double)src.v.integer;
-            else
-                H->syt[dest].val.v.scalar = src.v.scalar;
+            H->syt[dest].val.precision = prec;
+            H->syt[dest].val.v.scalar = v;
             H->syt[dest].allocated = 1;
         }
         break;

--- a/emu/halmat_engine.c
+++ b/emu/halmat_engine.c
@@ -25,6 +25,7 @@ halmat_val_t halmat_resolve_operand(halmat_t *H, uint32_t operand_word)
                 break;
             case 1: /* ARITH (single float) */
                 v.type = HTYPE_SCALAR;
+                v.precision = HPREC_SINGLE;
                 v.v.scalar = ibm_float_to_double((uint32_t)H->lit[data].lit2);
                 break;
             case 2: /* BIT */
@@ -33,6 +34,7 @@ halmat_val_t halmat_resolve_operand(halmat_t *H, uint32_t operand_word)
                 break;
             case 5: /* DOUBLE */
                 v.type = HTYPE_SCALAR;
+                v.precision = HPREC_DOUBLE;
                 v.v.scalar = ibm_double_to_double(
                     (uint32_t)H->lit[data].lit2,
                     (uint32_t)H->lit[data].lit3);
@@ -46,11 +48,13 @@ halmat_val_t halmat_resolve_operand(halmat_t *H, uint32_t operand_word)
 
     case QUAL_IMD:
         v.type = HTYPE_INTEGER;
+        v.precision = HPREC_SINGLE;
         v.v.integer = (int32_t)data;
         break;
 
     case QUAL_INL:
         v.type = HTYPE_INTEGER;
+        v.precision = HPREC_SINGLE;
         v.v.integer = (int32_t)data;
         break;
 

--- a/emu/halmat_io.c
+++ b/emu/halmat_io.c
@@ -94,6 +94,23 @@ void halmat_io_shutdown(halmat_t *H)
     }
 }
 
+/* HAL/S-FC User's Manual p. 6-2: SCALAR is " d.dddddddE±dd" (14 cols),
+ * SCALAR DOUBLE is " d.ddddddddddddddddE±dd" (23 cols). Programmer's Guide
+ * §12.2: exact zero is " 0.0" right-padded with blanks to field width.
+ * DEFAULT means COMMON0 wasn't loaded; preserve pre-precision-rework
+ * output by treating it as SINGLE. */
+static void write_scalar(FILE *fp, double v, uint8_t prec)
+{
+    int wide = (prec == HPREC_DOUBLE);
+    int width = wide ? 23 : 14;
+    if (v == 0.0)
+        fprintf(fp, "%-*s", width, " 0.0");
+    else if (wide)
+        fprintf(fp, "% .16E", v);
+    else
+        fprintf(fp, "% .7E", v);
+}
+
 static void write_char(halmat_t *H, FILE *fp, const char *data, int len)
 {
     if (H->translate_ebcdic) {
@@ -132,10 +149,7 @@ int halmat_io_write(halmat_t *H, int channel, halmat_val_t *args,
         case 5: {
             double v = (args[i].type == HTYPE_INTEGER)
                        ? (double)args[i].v.integer : args[i].v.scalar;
-            if (v == 0.0)
-                fprintf(fp, " 0.0");
-            else
-                fprintf(fp, "% .7E", v);
+            write_scalar(fp, v, args[i].precision);
             break;
         }
         case 6: {
@@ -147,12 +161,9 @@ int halmat_io_write(halmat_t *H, int channel, halmat_val_t *args,
         default:
             if (args[i].type == HTYPE_INTEGER)
                 fprintf(fp, "%11d", args[i].v.integer);
-            else if (args[i].type == HTYPE_SCALAR) {
-                if (args[i].v.scalar == 0.0)
-                    fprintf(fp, " 0.0");
-                else
-                    fprintf(fp, "% .7E", args[i].v.scalar);
-            } else if (args[i].type == HTYPE_CHAR)
+            else if (args[i].type == HTYPE_SCALAR)
+                write_scalar(fp, args[i].v.scalar, args[i].precision);
+            else if (args[i].type == HTYPE_CHAR)
                 write_char(H, fp, args[i].v.string.data, (int)args[i].v.string.len);
             break;
         }

--- a/emu/halmat_loader.c
+++ b/emu/halmat_loader.c
@@ -291,6 +291,110 @@ void halmat_free_common0(halmat_t *H)
     H->mem_image_loaded = 0;
 }
 
+/* COMMON0.out is the text TSV dump of the compiler's symbol table.
+ * Without it we can't distinguish SCALAR from SCALAR DOUBLE or
+ * INTEGER from INTEGER DOUBLE — the HALMAT operand words don't carry
+ * precision, only the SYM_FLAGS in this file do. Format documented by
+ * Ron Burkey's unHALMAT.py. */
+
+#define SYM_FLAG_SINGLE 0x00800000u
+#define SYM_FLAG_DOUBLE 0x00400000u
+
+static int field_at(const char *line, int idx, char *out, int out_sz)
+{
+    int cur = 0;
+    const char *p = line;
+    while (cur < idx) {
+        const char *t = strchr(p, '\t');
+        if (!t) return -1;
+        p = t + 1;
+        cur++;
+    }
+    const char *end = strchr(p, '\t');
+    if (!end) end = p + strlen(p);
+    /* strip trailing CR/LF on last field */
+    while (end > p && (end[-1] == '\n' || end[-1] == '\r')) end--;
+    int n = (int)(end - p);
+    if (n >= out_sz) n = out_sz - 1;
+    memcpy(out, p, n);
+    out[n] = '\0';
+    return n;
+}
+
+static uint8_t map_sym_type(uint32_t st)
+{
+    switch (st & 0xFF) {
+    case 0x01: return HTYPE_BIT;
+    case 0x02: return HTYPE_CHAR;
+    case 0x03: return HTYPE_MATRIX;
+    case 0x04: return HTYPE_VECTOR;
+    case 0x05: return HTYPE_SCALAR;
+    case 0x06: return HTYPE_INTEGER;
+    case 0x09: return HTYPE_EVENT;
+    case 0x0A: return HTYPE_STRUCT;
+    default:   return HTYPE_NONE;
+    }
+}
+
+int halmat_load_symtab(halmat_t *H, const char *filename)
+{
+    FILE *fp = fopen(filename, "r");
+    if (!fp) return -1;
+
+    char line[1024];
+    int  in_symtab = 0;
+    int  cur_idx = -1;
+
+    while (fgets(line, sizeof(line), fp)) {
+        if (!in_symtab) {
+            if (line[0] != '/') continue;
+            in_symtab = 1;
+        }
+
+        char f0[8], f1[64];
+        if (field_at(line, 0, f0, sizeof(f0)) < 0) break;
+
+        if (f0[0] == '/') {
+            char f2[16], f3[16];
+            if (field_at(line, 1, f1, sizeof(f1)) < 0) break;
+            if (field_at(line, 2, f2, sizeof(f2)) < 0) break;
+            if (field_at(line, 3, f3, sizeof(f3)) < 0) break;
+            if (strcmp(f1, "SYMuTAB") != 0 || strcmp(f3, "BASED") != 0)
+                break;
+            cur_idx = atoi(f2);
+            if (cur_idx < 0 || cur_idx >= HALMAT_MAX_SYT) {
+                cur_idx = -1;
+                continue;
+            }
+            if ((uint32_t)cur_idx >= H->syt_count)
+                H->syt_count = (uint32_t)cur_idx + 1;
+        } else if (f0[0] == '.' && cur_idx >= 0) {
+            if (field_at(line, 1, f1, sizeof(f1)) < 0) continue;
+            char fv[64];
+            if (field_at(line, 4, fv, sizeof(fv)) < 0) continue;
+
+            syt_entry_t *e = &H->syt[cur_idx];
+            if (strcmp(f1, "SYM_TYPE") == 0) {
+                uint32_t st = (uint32_t)strtoul(fv, NULL, 16);
+                uint8_t  ht = map_sym_type(st);
+                if (ht != HTYPE_NONE) {
+                    e->val.type = ht;
+                    e->declared = 1;
+                }
+            } else if (strcmp(f1, "SYM_FLAGS") == 0) {
+                uint32_t sf = (uint32_t)strtoul(fv, NULL, 16);
+                if (sf & SYM_FLAG_DOUBLE)      e->val.precision = HPREC_DOUBLE;
+                else if (sf & SYM_FLAG_SINGLE) e->val.precision = HPREC_SINGLE;
+            }
+        } else {
+            break;
+        }
+    }
+
+    fclose(fp);
+    return 0;
+}
+
 void halmat_decode_char_lit(halmat_t *H, uint32_t lit_idx, char *buf, int *len)
 {
     if (lit_idx >= H->lit_count) {

--- a/emu/halmat_types.h
+++ b/emu/halmat_types.h
@@ -15,11 +15,20 @@ enum {
     HTYPE_STRUCT  = 10
 };
 
+/* HAL/S precision: SCALAR is 32-bit float, SCALAR DOUBLE is 64-bit.
+ * INTEGER is 16-bit, INTEGER DOUBLE is 32-bit. Both narrow widths wrap.
+ * DEFAULT means COMMON0 wasn't loaded — fall back to wide width. */
+enum {
+    HPREC_DEFAULT = 0,
+    HPREC_SINGLE  = 1,
+    HPREC_DOUBLE  = 2
+};
+
 typedef struct {
     uint8_t  type;
+    uint8_t  precision;
     uint8_t  rows;
     uint8_t  cols;
-    uint8_t  _pad;
     union {
         int32_t  integer;
         double   scalar;
@@ -36,7 +45,8 @@ typedef struct {
 typedef struct {
     halmat_val_t val;
     uint8_t      allocated;
-    uint8_t      _pad[3];
+    uint8_t      declared;     /* 1 if type/precision came from COMMON0 */
+    uint8_t      _pad[2];
 } syt_entry_t;
 
 typedef struct {

--- a/emu/main.c
+++ b/emu/main.c
@@ -16,6 +16,8 @@ static void usage(const char *prog)
         "  --disasm       Disassemble only (no execution)\n"
         "  --litfile F    Load literal table (resolves LIT references)\n"
         "  --common F     Load COMMON memory image (.bin or .bin.gz)\n"
+        "  --symtab F     Load compiler symbol-table dump (COMMON0.out, TSV)\n"
+        "  --dump-symtab  Print loaded SYT entries and exit\n"
         "  --unit N=PATH  Map logical unit N to file (stdin/stdout/stderr for std streams)\n"
         "  --ebcdic       Translate character output from EBCDIC CP 037 to ASCII\n"
         "  --num-blanks N Number of blanks between WRITE fields (default: 5)\n"
@@ -30,7 +32,9 @@ int main(int argc, char *argv[])
     const char *halmat_file = NULL;
     const char *litfile = NULL;
     const char *common0 = NULL;
+    const char *symtab = NULL;
     int disasm_only = 0;
+    int dump_symtab = 0;
     int debug = 0;
     int trace = 0;
 
@@ -45,6 +49,10 @@ int main(int argc, char *argv[])
             litfile = argv[++i];
         } else if ((strcmp(argv[i], "--common") == 0 || strcmp(argv[i], "--common0") == 0) && i + 1 < argc) {
             common0 = argv[++i];
+        } else if (strcmp(argv[i], "--symtab") == 0 && i + 1 < argc) {
+            symtab = argv[++i];
+        } else if (strcmp(argv[i], "--dump-symtab") == 0) {
+            dump_symtab = 1;
         } else if (strcmp(argv[i], "--unit") == 0 && i + 1 < argc) {
             i++;
             char *eq = strchr(argv[i], '=');
@@ -153,6 +161,22 @@ int main(int argc, char *argv[])
         }
     }
 
+    if (symtab) {
+        if (halmat_load_symtab(&H, symtab) != 0)
+            fprintf(stderr, "warning: failed to load symbol table %s\n", symtab);
+    } else {
+        char autost[512];
+        const char *sep5 = strrchr(halmat_file, '/');
+        const char *sep6 = strrchr(halmat_file, '\\');
+        if (sep6 && (!sep5 || sep6 > sep5)) sep5 = sep6;
+        int dl5 = sep5 ? (int)(sep5 - halmat_file + 1) : 0;
+        if (sep5)
+            snprintf(autost, sizeof(autost), "%.*sCOMMON0.out", dl5, halmat_file);
+        else
+            snprintf(autost, sizeof(autost), "COMMON0.out");
+        halmat_load_symtab(&H, autost);
+    }
+
     if (!H.mem_image_loaded) {
         char autosrc[512];
         const char *sep3 = strrchr(halmat_file, '/');
@@ -185,6 +209,25 @@ int main(int argc, char *argv[])
     }
 
     halmat_build_flow_table(&H);
+
+    if (dump_symtab) {
+        static const char *type_names[] = {
+            "NONE", "BIT", "CHAR", "MATRIX", "VECTOR", "SCALAR",
+            "INTEGER", "BOOL", "?", "EVENT", "STRUCT"
+        };
+        static const char *prec_names[] = { "DEFAULT", "SINGLE", "DOUBLE" };
+        printf("SYT entries (count=%u):\n", H.syt_count);
+        for (uint32_t i = 0; i < H.syt_count; i++) {
+            uint8_t t = H.syt[i].val.type;
+            uint8_t p = H.syt[i].val.precision;
+            printf("  [%u] type=%-8s precision=%-7s declared=%u\n",
+                   i,
+                   (t < 11) ? type_names[t] : "?",
+                   (p < 3)  ? prec_names[p] : "?",
+                   H.syt[i].declared);
+        }
+        return 0;
+    }
 
     if (disasm_only) {
         printf("HALMAT DISASSEMBLY: %s\n", halmat_file);


### PR DESCRIPTION
## Summary

Adds a `precision` field to `halmat_val_t` and `syt_entry_t` so the
emulator can finally tell SCALAR from SCALAR DOUBLE and INTEGER from
INTEGER DOUBLE. HALMAT operands don't carry this; it lives in the
COMMON0.out TSV dump documented by Ron's unHALMAT.py.

- `halmat_load_symtab()` parses COMMON0.out (auto-detects next to halmat.bin, or `--symtab F`, plus `--dump-symtab` for inspection)
- Class 5/6 arithmetic propagates `max(a, b)` precision; SASN/IASN/SINT/IINT store at the destination's declared precision
- INTEGER ops wrap mod 2^16 on store (per Ron's AP-101S LH/MR/SLL/STH trace in #11); INTEGER DOUBLE keeps natural int32 wrap
- SCALAR stores via `(float)` cast so single and double aren't bitwise identical
- WRITE: 14 cols for SCALAR, 23 cols for SCALAR DOUBLE, `0.0` right-padded (HAL/S-FC User's Manual p.6-2 + Programmer's Guide §12.2)
- DFOR no longer clobbers an INTEGER loop variable to SCALAR

Refs #10 #11.

## Test plan

- [x] `make test-all` passes with byte-identical output to pre-change on all 9 existing samples (none of them use SCALAR or declare precision, so behavior is preserved when COMMON0.out is absent)
- [x] Synthetic COMMON0.out parser check: `--dump-symtab` correctly reports SCALAR/SCALAR DOUBLE/INTEGER with declared=1
- [ ] Ron's SCALAR_TEST.hal output matches expected (blocked: no HALSFC locally to compile)
- [ ] Ron's INTEGER_TEST.hal output matches expected (blocked: no HALSFC locally to compile)


Testing out AI to help draft up some of my messaging on commits. its going.....somewhere. 